### PR TITLE
PRODENG-2140 removed the 'mirantis' prefixes of the resources

### DIFF
--- a/mirantis/msr/connect/provider.go
+++ b/mirantis/msr/connect/provider.go
@@ -35,14 +35,14 @@ func Provider() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"mirantis-msr_user": ResourceUser(),
-			"mirantis-msr_org":  ResourceOrg(),
-			"mirantis-msr_team": ResourceTeam(),
-			"mirantis-msr_repo": ResourceRepo(),
+			"msr_user": ResourceUser(),
+			"msr_org":  ResourceOrg(),
+			"msr_team": ResourceTeam(),
+			"msr_repo": ResourceRepo(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"mirantis-msr_accounts": dataSourceAccounts(),
-			"mirantis-msr_account":  dataSourceAccount(),
+			"msr_accounts": dataSourceAccounts(),
+			"msr_account":  dataSourceAccount(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}


### PR DESCRIPTION
# Description

This pr removed the 'mirantis' prefixes of the resources so people using the terraform provider can refer to them by simply: 
`msr_{resource_}`

## Issue

https://mirantis.jira.com/browse/PRODENG-2140
