### PR TITLE
PRODENG-2159 Fixed wrong setID in the createRepo function

### DIFF
--- a/mirantis/msr/connect/resource_repository.go
+++ b/mirantis/msr/connect/resource_repository.go
@@ -62,7 +62,7 @@ func resourceRepoCreate(ctx context.Context, d *schema.ResourceData, m interface
 	if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(fmt.Sprintf("%s/%s", orgName, repo.Name))
+	d.SetId(createRepoID(ctx, orgName, repo.Name))
 
 	return diag.Diagnostics{}
 }


### PR DESCRIPTION
# Description

The id was set in the wrong format in the createRepo function

## Issue

https://mirantis.jira.com/browse/PRODENG-2159
