### PR TITLE
PRODENG-2428 Fixed Pruning policy duplicates and 504 hanging.

### DIFF
--- a/internal/client/pruning_policy.go
+++ b/internal/client/pruning_policy.go
@@ -33,13 +33,13 @@ type ResponsePruningPolicy struct {
 	Rules   []PruningPolicyRuleAPI `json:"rules"`
 }
 
-// CreatePruningPolicy creates a repo in MSR.
+// CreatePruningPolicy creates a pruning policy in MSR.
 func (c *Client) CreatePruningPolicy(ctx context.Context, orgName string, repoName string, policy CreatePruningPolicy) (ResponsePruningPolicy, error) {
 	body, err := json.Marshal(policy)
 	if err != nil {
 		return ResponsePruningPolicy{}, fmt.Errorf("creating pruning policy %+v failed. %w: %s", policy, ErrMarshaling, err)
 	}
-	url := fmt.Sprintf("%s/%s/%s/pruningPolicies?initialEvaluation=true", c.createMsrUrl("repositories"), orgName, repoName)
+	url := fmt.Sprintf("%s/%s/%s/pruningPolicies?initialEvaluation=false", c.createMsrUrl("repositories"), orgName, repoName)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
 	if err != nil {
 		return ResponsePruningPolicy{}, fmt.Errorf("creating pruning policy %+v failed. %w: %s", policy, ErrRequestCreation, err)
@@ -58,7 +58,7 @@ func (c *Client) CreatePruningPolicy(ctx context.Context, orgName string, repoNa
 	return resPolicy, nil
 }
 
-// ReadPruningPolicy creates a repo in MSR.
+// ReadPruningPolicy reads specific pruning policy of a repo in MSR.
 func (c *Client) ReadPruningPolicy(ctx context.Context, orgName string, repoName string, policyId string) (ResponsePruningPolicy, error) {
 	url := fmt.Sprintf("%s/%s/%s/pruningPolicies/%s", c.createMsrUrl("repositories"), orgName, repoName, policyId)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -78,7 +78,27 @@ func (c *Client) ReadPruningPolicy(ctx context.Context, orgName string, repoName
 	return resPolicy, nil
 }
 
-// DeletePruningPolicy creates a repo in MSR.
+// ReadPruningPolicy reads the pruning policies of a repo in MSR.
+func (c *Client) ReadPruningPolicies(ctx context.Context, orgName string, repoName string) ([]ResponsePruningPolicy, error) {
+	url := fmt.Sprintf("%s/%s/%s/pruningPolicies", c.createMsrUrl("repositories"), orgName, repoName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return []ResponsePruningPolicy{}, fmt.Errorf("reading pruning policies for %s/%s failed. %w: %s", orgName, repoName, ErrRequestCreation, err)
+	}
+	resBody, err := c.doRequest(req)
+	if err != nil {
+		return []ResponsePruningPolicy{}, fmt.Errorf("reading pruning policies for %s/%s failed. %w", orgName, repoName, err)
+	}
+
+	resPolicies := []ResponsePruningPolicy{}
+	if err := json.Unmarshal(resBody, &resPolicies); err != nil {
+		return []ResponsePruningPolicy{}, fmt.Errorf("reading pruning policies for %s/%s failed. %w: %s", orgName, repoName, ErrUnmarshaling, err)
+	}
+
+	return resPolicies, nil
+}
+
+// DeletePruningPolicy deletes a pruning policy in MSR.
 func (c *Client) DeletePruningPolicy(ctx context.Context, orgName string, repoName string, policyId string) error {
 	url := fmt.Sprintf("%s/%s/%s/pruningPolicies/%s", c.createMsrUrl("repositories"), orgName, repoName, policyId)
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
@@ -92,13 +112,13 @@ func (c *Client) DeletePruningPolicy(ctx context.Context, orgName string, repoNa
 	return err
 }
 
-// UpdatePruningPolicy creates a repo in MSR.
+// UpdatePruningPolicy updates a pruning policy in MSR.
 func (c *Client) UpdatePruningPolicy(ctx context.Context, orgName string, repoName string, policy CreatePruningPolicy, policyId string) (ResponsePruningPolicy, error) {
 	body, err := json.Marshal(policy)
 	if err != nil {
 		return ResponsePruningPolicy{}, fmt.Errorf("creating pruning policy %+v failed. %w: %s", policy, ErrMarshaling, err)
 	}
-	url := fmt.Sprintf("%s/%s/%s/pruningPolicies/%s?initialEvaluation=true", c.createMsrUrl("repositories"), orgName, repoName, policyId)
+	url := fmt.Sprintf("%s/%s/%s/pruningPolicies/%s?initialEvaluation=false", c.createMsrUrl("repositories"), orgName, repoName, policyId)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewBuffer(body))
 	if err != nil {
 		return ResponsePruningPolicy{}, fmt.Errorf("updating pruning policy for %s/%s failed. %w: %s", orgName, repoName, ErrRequestCreation, err)
@@ -115,4 +135,38 @@ func (c *Client) UpdatePruningPolicy(ctx context.Context, orgName string, repoNa
 	}
 
 	return resPolicy, nil
+}
+
+// PruningPolicyExists compares if a pruning policy exists within a existing pruning policies.
+func (c *Client) PruningPolicyExists(ctx context.Context, newPolicy CreatePruningPolicy, existingPolicies []ResponsePruningPolicy) ResponsePruningPolicy {
+
+	for _, policy := range existingPolicies {
+
+		if len(policy.Rules) != len(newPolicy.Rules) {
+			return ResponsePruningPolicy{}
+		}
+
+		var ruleMatch []bool
+		for _, existRule := range policy.Rules {
+			for _, newRule := range newPolicy.Rules {
+				// If the rule has Field and Operator matching compare Values
+				if existRule.Field == newRule.Field && existRule.Operator == newRule.Operator {
+					for _, existValue := range existRule.Values {
+						for _, newValue := range newRule.Values {
+							if existValue == newValue {
+								ruleMatch = append(ruleMatch, true)
+							}
+						}
+					}
+				}
+			}
+		}
+		// we have a policy match
+		if len(ruleMatch) == len(policy.Rules) {
+			return policy
+		}
+	}
+
+	// there is no matching existing policy in the MSR endpoint
+	return ResponsePruningPolicy{}
 }


### PR DESCRIPTION
# Description

1. Increased HTTP timeout to 240 seconds for the Pruning Policy client
2. Set the initialEvaluation to `false` of the pruning policy creation request
3. Implemented pruning policy duplicate detection prevention

## Issue

https://mirantis.jira.com/browse/PRODENG-2428
